### PR TITLE
docs: add quick localhost execution steps to SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -11,6 +11,21 @@ Este guia irá te ajudar a configurar e fazer o deploy do sistema de campeonatos
 
 ## 🚀 Passo a Passo Completo
 
+### ⚡ Execução rápida no localhost
+
+Se você só quer validar se o projeto está funcionando localmente, execute:
+
+```bash
+pnpm install
+pnpm run dev -- --host 0.0.0.0 --port 5173
+```
+
+Depois, abra no navegador:
+
+`http://localhost:5173`
+
+Para parar o servidor, pressione `Ctrl + C` no terminal.
+
 ### 1. Preparação do Ambiente
 
 #### 1.1 Verificar Node.js
@@ -228,4 +243,3 @@ Se encontrar problemas:
 ---
 
 **Boa sorte com seu campeonato! 🏆**
-


### PR DESCRIPTION
### Motivation
- Provide a minimal, quick-start instruction so contributors can validate the app runs locally with Vite and `pnpm` without reading the full setup guide. 
- Reduce friction when testing by giving exact commands and the URL to open in the browser.

### Description
- Added a new "⚡ Execução rápida no localhost" section to `SETUP.md` with the exact commands `pnpm install` and `pnpm run dev -- --host 0.0.0.0 --port 5173`.
- Documented the local URL `http://localhost:5173` and how to stop the dev server with `Ctrl + C`.
- This change is documentation-only and does not modify application source code or runtime behavior.

### Testing
- Verified environment with `node -v` and `pnpm -v`, which both succeeded. 
- Ran `pnpm install` successfully. 
- Built the project with `pnpm run build`, which completed successfully. 
- Started the dev server with `pnpm run dev -- --host 0.0.0.0 --port 5173` (run under a 15s timeout) and confirmed Vite served at `http://localhost:5173/` before the timeout terminated the process. 
- Note: local `dist/` build artifacts changed during validation but were intentionally not included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd68a60d8883318cbc915c617bdf70)